### PR TITLE
added a cmake and instructiosn on how to get API KEY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Set the project name
+project(NEOAnalyzer)
+
+# Specify the C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+# Add the executable
+file(GLOB SOURCES "src/*.cpp" "src/*.h")
+add_executable(NEOAnalyzer main.cpp ${SOURCES})
+
+# Find and include the nlohmann_json library
+find_package(nlohmann_json REQUIRED)
+target_link_libraries(NEOAnalyzer PRIVATE nlohmann_json::nlohmann_json)
+
+find_package(CURL REQUIRED)
+target_link_libraries(NEOAnalyzer PRIVATE CURL::libcurl)
+
+# Find and include the SFML library
+find_package(SFML 2.5 COMPONENTS graphics window system REQUIRED)
+target_link_libraries(NEOAnalyzer PRIVATE sfml-graphics sfml-window sfml-system)
+
+# Include directories
+target_include_directories(NEOAnalyzer PRIVATE  ${CMAKE_SOURCE_DIR}/src)
+

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ This project is configured to be compiled and run from VSCode. Follow these step
    ```
 5. Now, you can compile the code using the `.vscode` configuration (like `launch.json`, `settings.json`, `tasks.json`).
 
+### 3. Get NASA API Key
+To complete this step and be able to use this program visit [NASA API](https://api.nasa.gov/) and get your API key. Once done, create a `.env` file in the root directory and add the following line:
+```
+API_KEY=your_api_key
+```
+
 ## **Running the Application**
 
 ### 1. **Run the Main Application**

--- a/src/platform_config.h
+++ b/src/platform_config.h
@@ -7,10 +7,10 @@
     #include <nlohmann/json.hpp>
     #define OS_NAME "Windows"
 #elif defined(__APPLE__) || defined(__MACH__)
-    #include "../json.hpp" // Include for macOS
+    #include <nlohmann/json.hpp>
     #define OS_NAME "macOS"
 #elif defined(__linux__)
-    #include "json.hpp" // Include for Linux
+    #include <nlohmann/json.hpp>
     #define OS_NAME "Linux"
 #else
     #define OS_NAME "Unknown platform"


### PR DESCRIPTION
This pull request includes several important changes to the build configuration, documentation, and platform-specific includes. The most important changes are listed below:

### Build Configuration:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR1-R27): Added a new CMake configuration file to set up the project with C++17 standard, include necessary libraries (`nlohmann_json`, `CURL`, `SFML`), and specify the source files and include directories.

### Documentation:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R57-R62): Added instructions to obtain a NASA API key and set it up in a `.env` file.

### Platform-Specific Includes:

* [`src/platform_config.h`](diffhunk://#diff-ccd4394cd5fba555a729bafbe1b8c160d0690e178320e5fec870186747364443L10-R13): Updated the include paths for `nlohmann/json.hpp` to use the correct library path for each platform (Windows, macOS, Linux).